### PR TITLE
Fix header includes for stencil example

### DIFF
--- a/sycl_stencil/sycl_stencil.cpp
+++ b/sycl_stencil/sycl_stencil.cpp
@@ -1,5 +1,7 @@
 #include <sycl/sycl.hpp>
 #include <chrono>
+#include <algorithm>
+#include <numeric>
 
 using namespace sycl;
 


### PR DESCRIPTION
## Summary
- fix compile error by adding missing `<algorithm>` and `<numeric>` to stencil sample

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684c35a0686c832ebc32c6452c78e41c