### PR TITLE
Fix typos in SYCL device info examples

### DIFF
--- a/sycl_device_info/sycl_device_info.cpp
+++ b/sycl_device_info/sycl_device_info.cpp
@@ -3,7 +3,7 @@
 using namespace sycl;
 
 int main(){
-    // Loop through avaiable platforms
+    // Loop through available platforms
     for(auto const& this_platform: platform::get_platforms()){
         std::cout << "Platform: " << this_platform.get_info<info::platform::name>() << std::endl;
         // Loop through devices

--- a/sycl_device_info/sycl_device_more_info.cpp
+++ b/sycl_device_info/sycl_device_more_info.cpp
@@ -10,7 +10,7 @@ void do_query(const T& obj_to_query, const std::string& name, int indent = 4){
 }
 
 int main(){
-    // Loop through avaiable platforms
+    // Loop through available platforms
     for(auto const& this_platform: platform::get_platforms()){
         std::cout << "Found Platform:\n";
         do_query<info::platform::name>(this_platform, "info::platform::name");
@@ -18,7 +18,7 @@ int main(){
         do_query<info::platform::version>(this_platform, "info::platform::version");
         do_query<info::platform::profile>(this_platform, "info::platform::profile");
 
-        // Loop through devices avaiable in this platform
+        // Loop through devices available in this platform
         for(auto const& dev: this_platform.get_devices()){
             std::cout << "  Device: " << dev.get_info<info::device::name>() << "\n";
             std::cout << "  is_cpu(): " << (dev.is_cpu()? "Yes" : "No") << "\n";
@@ -32,7 +32,7 @@ int main(){
             do_query<info::device::mem_base_addr_align>(dev, "info::device::mem_base_addr_align");
             do_query<info::device::partition_max_sub_devices>(dev, "info::device::partition_max_sub_devices");
         
-            std::cout << "  Many more queries are avaiable than shown here!\n";
+            std::cout << "  Many more queries are available than shown here!\n";
         }
         std::cout << "\n";    
     }


### PR DESCRIPTION
## Summary
- correct spelling of `available` in device info examples

## Testing
- `grep -n "avaiable" -r sycl_device_info`

------
https://chatgpt.com/codex/tasks/task_e_684ce74b6f24832e84b1b98cd716eaee